### PR TITLE
Add Archlinux support

### DIFF
--- a/roles/local.fish/tasks/install-arch.yml
+++ b/roles/local.fish/tasks/install-arch.yml
@@ -1,0 +1,18 @@
+---
+- name: Arch | Install fish
+  pacman:
+    name: fish
+    state: present
+    update_cache: true
+  become: true
+
+- name: Arch | Lookup default shell
+  command: "awk -F: -v user='{{ ansible_user_id }}' '$1 == user {print $NF}' /etc/passwd"
+  register: default_shell
+  changed_when: false
+
+- name: Arch | Change default shell to fish
+  command: "chsh -s /usr/bin/fish {{ ansible_user_id }}"
+  become: true
+  when:
+    - default_shell.stdout != "/usr/bin/fish"

--- a/roles/local.fish/tasks/main.yml
+++ b/roles/local.fish/tasks/main.yml
@@ -43,6 +43,13 @@
   tags:
     - config
 
+- name: Install fish on Arch
+  import_tasks: install-arch.yml
+  when:
+    - ansible_distribution == "Archlinux"
+  tags:
+    - install
+
 - name: Install fish on macOS
   import_tasks: install-macos.yml
   when:

--- a/roles/local.gnupg/tasks/main.yml
+++ b/roles/local.gnupg/tasks/main.yml
@@ -23,6 +23,18 @@
   tags:
     - config
 
+- name: Arch | Install gpg
+  community.general.pacman:
+    name:
+      - gnupg
+    state: present
+    update_cache: true
+  when:
+    - ansible_distribution == "Archlinux"
+  become: true
+  tags:
+    - install
+
 - name: Ubuntu | Install gpg
   apt:
     name:

--- a/roles/local.kitty/tasks/main.yml
+++ b/roles/local.kitty/tasks/main.yml
@@ -13,6 +13,14 @@
   tags:
     - config
 
+- name: Arch | Install kitty
+  pacman:
+    name: kitty
+    state: present
+  become: true
+  when:
+    - ansible_distribution == "Archlinux"
+
 - name: macOS | Install kitty
   homebrew_cask:
     name: kitty

--- a/roles/local.neovim/tasks/main.yml
+++ b/roles/local.neovim/tasks/main.yml
@@ -11,6 +11,19 @@
   tags:
     - config
 
+- name: Arch | Install neovim
+  pacman:
+    name:
+      - neovim-git
+    executable: paru
+    state: present
+    update_cache: true
+  when:
+    - ansible_distribution == "Archlinux"
+  become: true
+  tags:
+    - install
+
 - name: macOS | Install neovim
   homebrew:
     name: neovim

--- a/roles/local.tmux/tasks/main.yml
+++ b/roles/local.tmux/tasks/main.yml
@@ -13,6 +13,14 @@
   tags:
     - config
 
+- name: Arch | Install tmux
+  pacman:
+    name: tmux
+    state: present
+  become: true
+  when:
+    - ansible_distribution == "Archlinux"
+
 - name: macOS | Install tmux
   homebrew:
     name: tmux


### PR DESCRIPTION
  Caveats:
    - paru needs to be installed and that's how we install neovim-git manually `paru -Sy neovim-git`
    - Rust programs in ASDF don't work so we install them with rustup.
    - Need to add ~/.cargo/bin to path

Signed-off-by: Thomas Miller <git@me.tmiller.dev>